### PR TITLE
Fix rubocop warnings

### DIFF
--- a/benchmarks/rubocop/.rubocop.yml
+++ b/benchmarks/rubocop/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
 


### PR DESCRIPTION
This PR fixes the following warnings:

```
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /home/k0kubun/src/github.com/ruby/ruby-bench/benchmarks/rubocop/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /home/k0kubun/src/github.com/ruby/ruby-bench/benchmarks/rubocop/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```