### PR TITLE
Fork stackprof and concurrent-ruby for deprecated API

### DIFF
--- a/benchmarks/activerecord/Gemfile
+++ b/benchmarks/activerecord/Gemfile
@@ -5,3 +5,4 @@ gem "activerecord-jdbcsqlite3-adapter", "~> 70", platform: :jruby
 gem "mutex_m"
 gem "bigdecimal"
 gem "base64"
+gem "concurrent-ruby", github: "ruby-concurrency/concurrent-ruby"

--- a/benchmarks/activerecord/Gemfile.lock
+++ b/benchmarks/activerecord/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/ruby-concurrency/concurrent-ruby.git
+  revision: 978eed6c317c523a5ce31769bdf46c0f947e6fdb
+  specs:
+    concurrent-ruby (1.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -23,7 +29,6 @@ GEM
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
-    concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     drb (2.2.3)
     i18n (1.14.7)
@@ -50,6 +55,7 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter (~> 70)
   base64
   bigdecimal
+  concurrent-ruby!
   mutex_m
   sqlite3
 
@@ -60,7 +66,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.4.1) sha256=d4ef40037bba27f03b28013e219b950b82bace296549ec15a78016552f8d2cce
   bigdecimal (3.2.2) sha256=39085f76b495eb39a79ce07af716f3a6829bc35eb44f2195e2753749f2fa5adc
-  concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
+  concurrent-ruby (1.3.5)
   connection_pool (2.5.3) sha256=cfd74a82b9b094d1ce30c4f1a346da23ee19dc8a062a16a85f58eab1ced4305b
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   i18n (1.14.7) sha256=ceba573f8138ff2c0915427f1fc5bdf4aa3ab8ae88c8ce255eb3ecf0a11a5d0f

--- a/benchmarks/erubi-rails/Gemfile
+++ b/benchmarks/erubi-rails/Gemfile
@@ -39,6 +39,7 @@ gem 'jbuilder', '~> 2.7'
 #gem 'bootsnap', '>= 1.4.4', require: false
 
 gem 'mutex_m'
+gem 'concurrent-ruby', github: 'ruby-concurrency/concurrent-ruby'
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.

--- a/benchmarks/erubi-rails/Gemfile.lock
+++ b/benchmarks/erubi-rails/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/ruby-concurrency/concurrent-ruby.git
+  revision: 978eed6c317c523a5ce31769bdf46c0f947e6fdb
+  specs:
+    concurrent-ruby (1.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -59,7 +65,6 @@ GEM
       xpath (~> 3.2)
     cgi (0.5.0)
     childprocess (4.1.0)
-    concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
     date (3.4.1)
@@ -210,6 +215,7 @@ DEPENDENCIES
   bigdecimal
   capybara (>= 3.26)
   cgi
+  concurrent-ruby!
   jbuilder (~> 2.7)
   mutex_m
   net-imap (~> 0.2.1)
@@ -240,7 +246,7 @@ CHECKSUMS
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.0) sha256=fe99f65bb2c146e294372ebb27602adbc3b4c008e9ea7038c6bd48c1ec9759da
   childprocess (4.1.0) sha256=3616ce99ccb242361ce7f2b19bf9ff3e6bc1d98b927c7edc29af8ca617ba6cd3
-  concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
+  concurrent-ruby (1.3.5)
   connection_pool (2.5.3) sha256=cfd74a82b9b094d1ce30c4f1a346da23ee19dc8a062a16a85f58eab1ced4305b
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   date (3.4.1) sha256=bf268e14ef7158009bfeaec40b5fa3c7271906e88b196d958a89d4b408abe64f

--- a/benchmarks/fluentd/Gemfile
+++ b/benchmarks/fluentd/Gemfile
@@ -4,3 +4,4 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'csv'
 gem 'fluentd'
 gem 'base64'
+gem 'concurrent-ruby', github: 'ruby-concurrency/concurrent-ruby'

--- a/benchmarks/fluentd/Gemfile.lock
+++ b/benchmarks/fluentd/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/ruby-concurrency/concurrent-ruby.git
+  revision: 978eed6c317c523a5ce31769bdf46c0f947e6fdb
+  specs:
+    concurrent-ruby (1.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -20,7 +26,6 @@ GEM
     async-pool (0.11.0)
       async (>= 2.0)
     base64 (0.3.0)
-    concurrent-ruby (1.3.5)
     console (1.33.0)
       fiber-annotation
       fiber-local (~> 1.1)
@@ -90,6 +95,7 @@ PLATFORMS
 
 DEPENDENCIES
   base64
+  concurrent-ruby!
   csv
   fluentd
 
@@ -98,7 +104,7 @@ CHECKSUMS
   async-http (0.89.0) sha256=1a40728cf38ec4c3eff121474bd4f218237ffff177e471ca677b57d7aa436682
   async-pool (0.11.0) sha256=2228c4a8d1ca59a259b5f9dab7e0f9f23d57856b195aca1c0aa684a7439ea525
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
+  concurrent-ruby (1.3.5)
   console (1.33.0) sha256=a1cc1910e3b24169b4925e42d72da414d53e5bd6773aee9a811e57dfe0399384
   cool.io (1.9.1) sha256=2001bfec1b87ad5e87c0eb9f197a6ee6f1a0433ddba04002227da6ee8b74c6c1
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f

--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -22,6 +22,7 @@ gem 'scenic'
 #gem 'scenic-mysql_adapter'
 gem "activerecord-typedstore"
 gem 'sprockets-rails', '2.3.3'
+gem 'concurrent-ruby', github: 'ruby-concurrency/concurrent-ruby'
 
 # js
 gem "jquery-rails", "~> 4.3"
@@ -52,7 +53,7 @@ group :development do
   gem 'flamegraph'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'stackprof'
+  gem 'stackprof', github: 'nobu/stackprof', branch: 'postponed_jobs'
 end
 
 gem "oauth" # for twitter-posting bot

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -1,4 +1,17 @@
 GIT
+  remote: https://github.com/nobu/stackprof.git
+  revision: 7d4b181569c04c9a35d0b4250cfbc535760ac18d
+  branch: postponed_jobs
+  specs:
+    stackprof (0.2.27)
+
+GIT
+  remote: https://github.com/ruby-concurrency/concurrent-ruby.git
+  revision: 978eed6c317c523a5ce31769bdf46c0f947e6fdb
+  specs:
+    concurrent-ruby (1.3.5)
+
+GIT
   remote: https://github.com/whomwah/rqrcode.git
   revision: f9fa33704951158a38b3cf04311e295d3a0e947d
   specs:
@@ -106,7 +119,6 @@ GEM
     cgi (0.5.0)
     chunky_png (1.4.0)
     commonmarker (0.23.11)
-    concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crack (1.0.0)
       bigdecimal
@@ -302,7 +314,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
     sqlite3 (2.7.3)
       mini_portile2 (~> 2.8.0)
-    stackprof (0.2.27)
     stringio (3.1.7)
     svg-graph (2.2.2)
     thor (1.4.0)
@@ -348,6 +359,7 @@ DEPENDENCIES
   capybara
   cgi
   commonmarker (>= 0.23.6, < 1.0)
+  concurrent-ruby!
   database_cleaner
   factory_bot_rails
   faker
@@ -378,7 +390,7 @@ DEPENDENCIES
   sitemap_generator
   sprockets-rails (= 2.3.3)
   sqlite3
-  stackprof
+  stackprof!
   svg-graph
   vcr
   webmock
@@ -409,7 +421,7 @@ CHECKSUMS
   cgi (0.5.0) sha256=fe99f65bb2c146e294372ebb27602adbc3b4c008e9ea7038c6bd48c1ec9759da
   chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe
   commonmarker (0.23.11) sha256=9d1d35d358740151bce29235aebfecc63314fb57dd89a83e72d4061b4fe3d2bf
-  concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
+  concurrent-ruby (1.3.5)
   connection_pool (2.5.3) sha256=cfd74a82b9b094d1ce30c4f1a346da23ee19dc8a062a16a85f58eab1ced4305b
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
@@ -502,7 +514,7 @@ CHECKSUMS
   sprockets (3.7.5) sha256=72c20f256548f8a37fe7db41d96be86c3262fddaf4ebe9d69ec8317394fed383
   sprockets-rails (2.3.3) sha256=968794c910cc395ae10a68e3d4f5801f946b7698103e42ed49f7cad67d3654ef
   sqlite3 (2.7.3) sha256=d2b2fecd9341132f2cea3fde9061ee0fab9c9d532a8ecccfab4fe63d9621bf57
-  stackprof (0.2.27) sha256=aff6d28656c852e74cf632cc2046f849033dc1dedffe7cb8c030d61b5745e80c
+  stackprof (0.2.27)
   stringio (3.1.7) sha256=5b78b7cb242a315fb4fca61a8255d62ec438f58da2b90be66048546ade4507fa
   svg-graph (2.2.2) sha256=f928866403055e6539afdfdab5f6268d108b2abc9f002e0fc51b16511809513a
   thor (1.4.0) sha256=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d

--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -18,7 +18,7 @@ end
 
 gem 'sprockets-rails', '3.2.2'
 
-gem 'stackprof', platforms: :mri
+gem 'stackprof', platforms: :mri, github: 'nobu/stackprof', branch: 'postponed_jobs'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', platform: :ruby
 gem 'activerecord-jdbcsqlite3-adapter', '~> 70', platform: :jruby
@@ -28,6 +28,7 @@ gem 'webrick', '~> 1.8.2'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # Needed in the benchmark for json responses
 gem 'jbuilder', '~> 2.7'
+gem 'concurrent-ruby', github: 'ruby-concurrency/concurrent-ruby'
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 # gem 'webpacker', '~> 4.0'

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/nobu/stackprof.git
+  revision: 7d4b181569c04c9a35d0b4250cfbc535760ac18d
+  branch: postponed_jobs
+  specs:
+    stackprof (0.2.27)
+
+GIT
+  remote: https://github.com/ruby-concurrency/concurrent-ruby.git
+  revision: 978eed6c317c523a5ce31769bdf46c0f947e6fdb
+  specs:
+    concurrent-ruby (1.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -71,7 +84,6 @@ GEM
     bigdecimal (3.2.2)
     builder (3.3.0)
     cgi (0.5.0)
-    concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
     digest (3.2.0)
@@ -165,7 +177,6 @@ GEM
     sqlite3 (2.7.3)
       mini_portile2 (~> 2.8.0)
     sqlite3 (2.7.3-x86_64-linux-gnu)
-    stackprof (0.2.27)
     strscan (3.1.5)
     thor (1.4.0)
     timeout (0.4.3)
@@ -196,6 +207,7 @@ DEPENDENCIES
   base64
   bigdecimal
   cgi
+  concurrent-ruby!
   jbuilder (~> 2.7)
   mutex_m
   net-imap (~> 0.2.1)
@@ -205,7 +217,7 @@ DEPENDENCIES
   railties (~> 8.0)
   sprockets-rails (= 3.2.2)
   sqlite3
-  stackprof
+  stackprof!
   tzinfo-data
   webrick (~> 1.8.2)
 
@@ -225,7 +237,7 @@ CHECKSUMS
   bigdecimal (3.2.2) sha256=39085f76b495eb39a79ce07af716f3a6829bc35eb44f2195e2753749f2fa5adc
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   cgi (0.5.0) sha256=fe99f65bb2c146e294372ebb27602adbc3b4c008e9ea7038c6bd48c1ec9759da
-  concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
+  concurrent-ruby (1.3.5)
   connection_pool (2.5.3) sha256=cfd74a82b9b094d1ce30c4f1a346da23ee19dc8a062a16a85f58eab1ced4305b
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   digest (3.2.0) sha256=fa2e7092ec683f65d82fadde5ff4ca3b32e23ee0b19f1fc1a5e09993ad2d3991
@@ -269,7 +281,7 @@ CHECKSUMS
   sprockets-rails (3.2.2) sha256=62862bce136e31d7497eededde5f7730d4096bc8ef33ef7037c41423ccf89557
   sqlite3 (2.7.3) sha256=d2b2fecd9341132f2cea3fde9061ee0fab9c9d532a8ecccfab4fe63d9621bf57
   sqlite3 (2.7.3-x86_64-linux-gnu) sha256=11b2612fddf56602d238be7a984fa0633e591edd034f7520747bc0927b7fa865
-  stackprof (0.2.27) sha256=aff6d28656c852e74cf632cc2046f849033dc1dedffe7cb8c030d61b5745e80c
+  stackprof (0.2.27)
   strscan (3.1.5) sha256=f8413b90ea9395a69609a4414a8c88551bcda64337e234272c24fcd4c83e5947
   thor (1.4.0) sha256=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d
   timeout (0.4.3) sha256=9509f079b2b55fe4236d79633bd75e34c1c1e7e3fb4b56cb5fda61f80a0fe30e

--- a/benchmarks/rubocop/Gemfile
+++ b/benchmarks/rubocop/Gemfile
@@ -6,3 +6,4 @@ gem "parser", ">= 3.2.2.3" # Avoid a fun ruby-lsp/rubocop bug
 gem "rubocop"
 gem "rubocop-performance"
 gem "rubocop-rails"
+gem "concurrent-ruby", github: "ruby-concurrency/concurrent-ruby"

--- a/benchmarks/rubocop/Gemfile.lock
+++ b/benchmarks/rubocop/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/ruby-concurrency/concurrent-ruby.git
+  revision: 978eed6c317c523a5ce31769bdf46c0f947e6fdb
+  specs:
+    concurrent-ruby (1.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -18,7 +24,6 @@ GEM
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
-    concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     drb (2.2.3)
     i18n (1.14.7)
@@ -75,6 +80,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  concurrent-ruby!
   parser (>= 3.2.2.3)
   rubocop
   rubocop-performance
@@ -86,7 +92,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.4.1) sha256=d4ef40037bba27f03b28013e219b950b82bace296549ec15a78016552f8d2cce
   bigdecimal (3.2.2) sha256=39085f76b495eb39a79ce07af716f3a6829bc35eb44f2195e2753749f2fa5adc
-  concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
+  concurrent-ruby (1.3.5)
   connection_pool (2.5.3) sha256=cfd74a82b9b094d1ce30c4f1a346da23ee19dc8a062a16a85f58eab1ced4305b
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   i18n (1.14.7) sha256=ceba573f8138ff2c0915427f1fc5bdf4aa3ab8ae88c8ce255eb3ecf0a11a5d0f

--- a/benchmarks/shipit/Gemfile
+++ b/benchmarks/shipit/Gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 8.0.2"
 gem "sqlite3", ">= 2.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
+gem "concurrent-ruby", github: "ruby-concurrency/concurrent-ruby"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/benchmarks/shipit/Gemfile.lock
+++ b/benchmarks/shipit/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/ruby-concurrency/concurrent-ruby.git
+  revision: 978eed6c317c523a5ce31769bdf46c0f947e6fdb
+  specs:
+    concurrent-ruby (1.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -97,7 +103,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
     date (3.4.1)
@@ -381,6 +386,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  concurrent-ruby!
   puma (>= 5.0)
   rails (~> 8.0.2)
   shipit-engine (>= 0.40.0)
@@ -412,7 +418,7 @@ CHECKSUMS
   coffee-rails (5.0.0) sha256=5daaa1ba51fd4907c98a333b6a9e7c1a99b1fff57fcef999b6c62d813cb91a9c
   coffee-script (2.4.1) sha256=82fe281e11b93c8117b98c5ea8063e71741870f1c4fbb27177d7d6333dd38765
   coffee-script-source (1.12.2) sha256=e12b16fd8927fbbf8b87cb2e9a85a6cf457c6881cc7ff8b1af15b31f70da07a4
-  concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
+  concurrent-ruby (1.3.5)
   connection_pool (2.5.3) sha256=cfd74a82b9b094d1ce30c4f1a346da23ee19dc8a062a16a85f58eab1ced4305b
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   date (3.4.1) sha256=bf268e14ef7158009bfeaec40b5fa3c7271906e88b196d958a89d4b408abe64f


### PR DESCRIPTION
This is prepared in case we decide to merge https://github.com/ruby/ruby/pull/15447.