### PR TITLE
Add send-with-block benchmark

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -162,6 +162,10 @@ attr_accessor:
   category: micro
   single_file: true
   ractor: true
+block_methods:
+  desc: calls a handful of builtin Ruby methods that take blocks.
+  category: micro
+  single_file: true
 cfunc_itself:
   desc: cfunc_itself just calls the 'itself' method many, many times.
   category: micro

--- a/benchmarks/block_methods.rb
+++ b/benchmarks/block_methods.rb
@@ -1,0 +1,79 @@
+require_relative '../harness/loader'
+
+def array_each(array)
+  array.each do |x|
+    x * 2
+  end
+  array.each do |x|
+    x * 4
+  end
+end
+
+def array_map(array)
+  array.map do |x|
+    x * 2
+  end
+  array.map do |x|
+    x * 4
+  end
+end
+
+def array_select(array)
+  array.select do |x|
+    x.even?
+  end
+  array.select do |x|
+    x.odd?
+  end
+end
+
+def integer_times(integer)
+  integer.times do |i|
+    i * 2
+  end
+  integer.times do |i|
+    i * 4
+  end
+end
+
+def kernel_tap(x)
+  i = 0
+  while i < x
+    x.tap do |y|
+      y * 2
+    end
+    x.tap do |y|
+      y * 4
+    end
+    i += 1
+  end
+end
+
+def kernel_then(x)
+  i = 0
+  while i < x
+    x.then do |y|
+      y * 2
+    end
+    x.then do |y|
+      y * 4
+    end
+    i += 1
+  end
+end
+
+K = 100_000
+ARRAY = (1..K).to_a
+
+run_benchmark(1000) do
+  i = 0
+  while i < 10
+    array_each(ARRAY)
+    array_map(ARRAY)
+    array_select(ARRAY)
+    integer_times(K)
+    kernel_tap(K)
+    kernel_then(K)
+    i += 1
+  end
+end


### PR DESCRIPTION
Benchmarks send-with-block, especially polymorphic send-with-block. Gives us information on how much inlining-driven monomorphization is helping.